### PR TITLE
re-pairing vec2 handlers for i32,f32,u32

### DIFF
--- a/src/buffer-views.ts
+++ b/src/buffer-views.ts
@@ -64,9 +64,9 @@ const b: Record<string, TypeDef> = {
 const typeInfo: Record<string, TypeDef> = {
   ...b,
 
-  'vec2<i32>': b.vec2f,
-  'vec2<u32>': b.vec2i,
-  'vec2<f32>': b.vec2u,
+  'vec2<i32>': b.vec2i,
+  'vec2<u32>': b.vec2u,
+  'vec2<f32>': b.vec2f,
   'vec2<f16>': b.vec2h,
   'vec3<i32>': b.vec3i,
   'vec3<u32>': b.vec3u,


### PR DESCRIPTION
ran into an issue where vec2 uniforms were not being sent to shaders because the buffers i was creating were (i think?) allocating the wrong size/type of memory for each uniform