### PR TITLE
Enhance type safety in StructuredView

### DIFF
--- a/src/buffer-views.ts
+++ b/src/buffer-views.ts
@@ -384,7 +384,7 @@ export function setStructuredView(data: any, views: TypedArrayOrViews): void {
     }
 }
 
-export type StructuredView = ArrayBufferViews & {
+export type StructuredView<ViewType extends TypeDefinition> = ArrayBufferViews & {
     /**
      * Sets the contents of the TypedArrays based on the data passed in
      * Note: The data may be sparse
@@ -425,7 +425,7 @@ export type StructuredView = ArrayBufferViews & {
      *
      * @param data
      */
-    set(data: any): void;
+    set(data: ViewType extends StructDefinition ? Partial<Record<keyof ViewType['fields'],any>> : any): void;
 }
 
 /**
@@ -436,13 +436,13 @@ export type StructuredView = ArrayBufferViews & {
  * @returns TypedArray views for the various named fields of the structure as well
  *    as a `set` function to make them easy to set, and the arrayBuffer
  */
-export function makeStructuredView(varDef: VariableDefinition | StructDefinition, arrayBuffer?: ArrayBuffer, offset = 0): StructuredView {
+export function makeStructuredView<InputType extends VariableDefinition | StructDefinition, ViewType extends TypeDefinition = InputType extends VariableDefinition ? InputType['typeDefinition'] : InputType>(varDef: InputType, arrayBuffer?: ArrayBuffer, offset = 0): StructuredView<ViewType> {
     const asVarDef = varDef as VariableDefinition;
-    const typeDef = asVarDef.group === undefined ? varDef as StructDefinition : asVarDef.typeDefinition;
+    const typeDef = asVarDef.group === undefined ? varDef as unknown as ViewType : asVarDef.typeDefinition as ViewType;
     const views = makeTypedArrayViews(typeDef, arrayBuffer, offset);
     return {
         ...views,
-        set(data: any) {
+        set(data) {
             setStructuredView(data, views.views);
         },
     };


### PR DESCRIPTION
This is super quick and I', sure if this is worth adding unless we also add the ability to type check the values rather then just the keys, but I'm working on putting together a typescript plugin which hopefully will allow typescript to access the type definitions of a script at compile/development time so with this change you could ensure that struct member names match those in the shader