### PR TITLE
Add Uint8ClampedArray to TypedArray type

### DIFF
--- a/src/typed-arrays.ts
+++ b/src/typed-arrays.ts
@@ -5,6 +5,7 @@ import {
 export type TypedArrayConstructor =
     | Int8ArrayConstructor
     | Uint8ArrayConstructor
+    | Uint8ClampedArrayConstructor
     | Int16ArrayConstructor
     | Uint16ArrayConstructor
     | Int32ArrayConstructor
@@ -15,6 +16,7 @@ export type TypedArrayConstructor =
 export type TypedArray =
     | Int8Array
     | Uint8Array
+    | Uint8ClampedArray
     | Int16Array
     | Uint16Array
     | Int32Array


### PR DESCRIPTION
The [Uint8ClampedArray][1] type behaves very similarly to Uint8Array, and should probably be mentioned among the other typed arrays.

This lines up with [d3's definition of TypedArray][2].

[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8ClampedArray
[2]: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/d3-interpolate/index.d.ts#L44-L53