### PR TITLE
Enable use in WebWorkers

### DIFF
--- a/src/texture-utils.ts
+++ b/src/texture-utils.ts
@@ -247,7 +247,7 @@ export type CreateTextureOptions = CopyTextureOptions & {
  * sources have a different way to get their size.
  */
 export function getSizeFromSource(source: TextureSource, options: CreateTextureOptions): number[] {
-  if (source instanceof HTMLVideoElement) {
+  if ('videoWidth' in source  && 'videoHeight' in source) {
     return [source.videoWidth, source.videoHeight, 1];
   } else {
     const maybeHasWidthAndHeight = source as { width: number, height: number };


### PR DESCRIPTION
## Description

Adds the ability to use the library in WebWorkers (which is useful for `OffscreenCanvas` rendering). DOM APIs aren't accessible from a WebWorker, so the `instanceof HTMLVideoElement` check was limiting the library use to the main thread.

## Overview of Changes

- Replace `instanceof HTMLVideoElement` check with simple property check